### PR TITLE
Improve detection of element in query

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -61,7 +61,7 @@ class Translator {
 		$thread = array_values($thread);
 
 		$xpath = [$this->prefix];
-		$prevType = "";
+        $hasElement = false;
 		foreach($thread as $threadKey => $currentThreadItem) {
 			$next = isset($thread[$threadKey + 1])
 				? $thread[$threadKey + 1]
@@ -71,6 +71,7 @@ class Translator {
 			case "star":
 			case "element":
 				$xpath []= $currentThreadItem['content'];
+                $hasElement = true;
 				break;
 
 			case "pseudo":
@@ -160,23 +161,26 @@ class Translator {
 
 			case "child":
 				array_push($xpath, "/");
+                $hasElement = false;
 				break;
 
 			case "id":
 				array_push(
 					$xpath,
-					($prevType != "element"  ? '*' : '')
+					($hasElement ? '' : '*')
 					. "[@id='{$currentThreadItem['content']}']"
 				);
+                $hasElement = true;
 				break;
 
 			case "class":
 				// https://devhints.io/xpath#class-check
 				array_push(
 					$xpath,
-					(($prevType != "element" && $prevType != "class") ? '*' : '')
+                    ($hasElement ? '' : '*')
 					. "[contains(concat(' ',normalize-space(@class),' '),' {$currentThreadItem['content']} ')]"
 				);
+                $hasElement = true;
 				break;
 
 			case "sibling":
@@ -184,11 +188,13 @@ class Translator {
 					$xpath,
 					"/following-sibling::*[1]/self::"
 				);
+                $hasElement = false;
 				break;
 
 			case "attribute":
-				if(!$prevType) {
+				if(!$hasElement) {
 					array_push($xpath, "*");
+                    $hasElement = true;
 				}
 
 				/** @var null|array<int, array<string, string>> $detail */
@@ -257,10 +263,9 @@ class Translator {
 
 			case "descendant":
 				array_push($xpath, "//");
+                $hasElement = false;
 				break;
 			}
-
-			$prevType = $currentThreadItem["type"];
 		}
 
 		return implode("", $xpath);

--- a/test/phpunit/Helper/Helper.php
+++ b/test/phpunit/Helper/Helper.php
@@ -169,11 +169,11 @@ HTML;
 
 <main>
 	<div class="content">First content without ID</div>
-    <div id="content-element" class="content">Content with ID</div>
-    <div class="content">Second content without ID</div>
-    <div class="content" data-attr="1">Content with attribute 1</div>
-    <div class="content" data-attr="2">Content with attribute 2</div>
-    <div class="content">Third content without ID</div>
+	<div id="content-element" class="content">Content with ID</div>
+	<div class="content">Second content without ID</div>
+	<div class="content" data-attr="1">Content with attribute 1</div>
+	<div class="content" data-attr="2">Content with attribute 2</div>
+	<div class="content">Third content without ID</div>
 </main>
 
 </body>

--- a/test/phpunit/Helper/Helper.php
+++ b/test/phpunit/Helper/Helper.php
@@ -156,4 +156,27 @@ HTML;
 </form>
 HTML;
 
+    const HTML_SELECTORS = <<<HTML
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>HTML Complex</title>
+</head>
+<body>
+
+
+<main>
+	<div class="content">First content without ID</div>
+    <div id="content-element" class="content">Content with ID</div>
+    <div class="content">Second content without ID</div>
+    <div class="content" data-attr="1">Content with attribute 1</div>
+    <div class="content" data-attr="2">Content with attribute 2</div>
+    <div class="content">Third content without ID</div>
+</main>
+
+</body>
+</html>
+HTML;
 }

--- a/test/phpunit/TranslatorTest.php
+++ b/test/phpunit/TranslatorTest.php
@@ -421,4 +421,15 @@ class TranslatorTest extends TestCase {
 		$choiceInputs = $xpath->query($choiceTranslator);
 		self::assertEquals(3, $choiceInputs->length);
 	}
+
+	public function testMultipleNamedElements() {
+		$document = new DOMDocument("1.0", "UTF-8");
+		$document->loadHTML(Helper::HTML_SELECTS);
+		$xpath = new DOMXPath($document);
+		$translator = new Translator("form [name='from'], form [name='to']");
+		$selectElements = $xpath->query($translator);
+		self::assertEquals(2, $selectElements->length);
+		self::assertSame("from", $selectElements->item(0)->getAttribute("name"));
+		self::assertSame("to", $selectElements->item(1)->getAttribute("name"));
+	}
 }

--- a/test/phpunit/TranslatorTest.php
+++ b/test/phpunit/TranslatorTest.php
@@ -228,7 +228,7 @@ class TranslatorTest extends TestCase {
 		)->item(0);
 		self::assertSame($navElement, $navElement2);
 
- 		$navElement3 = $xpath->query(
+		$navElement3 = $xpath->query(
 			new Translator("nav.c-menu.main-selection")
 		)->item(0);
 		self::assertSame($navElement, $navElement3);
@@ -398,27 +398,27 @@ class TranslatorTest extends TestCase {
 		self::assertEquals(3, $choiceInputs->length);
 	}
 
-    public function testCombinedSelectors() {
-        $document = new DOMDocument("1.0", "UTF-8");
-        $document->loadHTML(Helper::HTML_SELECTORS);
-        $xpath = new DOMXPath($document);
+	public function testCombinedSelectors() {
+		$document = new DOMDocument("1.0", "UTF-8");
+		$document->loadHTML(Helper::HTML_SELECTORS);
+		$xpath = new DOMXPath($document);
 
-        $classIdTranslator = new Translator(".content#content-element");
-        $classAttr2Translator = new Translator(".content[data-attr='2']");
+		$classIdTranslator = new Translator(".content#content-element");
+		$classAttr2Translator = new Translator(".content[data-attr='2']");
 
-        $titleEl = $xpath->query($classIdTranslator)->item(0);
-        self::assertEquals("Content with ID", $titleEl->nodeValue);
+		$titleEl = $xpath->query($classIdTranslator)->item(0);
+		self::assertEquals("Content with ID", $titleEl->nodeValue);
 
-        $attr2El = $xpath->query($classAttr2Translator)->item(0);
-        self::assertEquals("Content with attribute 2", $attr2El->nodeValue);
-    }
+		$attr2El = $xpath->query($classAttr2Translator)->item(0);
+		self::assertEquals("Content with attribute 2", $attr2El->nodeValue);
+	}
 
-    public function testChildWithAttribute() {
-        $document = new DOMDocument("1.0", "UTF-8");
-        $document->loadHTML(Helper::HTML_CHECKBOX);
-        $xpath = new DOMXPath($document);
-        $choiceTranslator = new Translator("form [name]");
-        $choiceInputs = $xpath->query($choiceTranslator);
-        self::assertEquals(3, $choiceInputs->length);
-    }
+	public function testChildWithAttribute() {
+		$document = new DOMDocument("1.0", "UTF-8");
+		$document->loadHTML(Helper::HTML_CHECKBOX);
+		$xpath = new DOMXPath($document);
+		$choiceTranslator = new Translator("form [name]");
+		$choiceInputs = $xpath->query($choiceTranslator);
+		self::assertEquals(3, $choiceInputs->length);
+	}
 }

--- a/test/phpunit/TranslatorTest.php
+++ b/test/phpunit/TranslatorTest.php
@@ -397,4 +397,28 @@ class TranslatorTest extends TestCase {
 
 		self::assertEquals(3, $choiceInputs->length);
 	}
+
+    public function testCombinedSelectors() {
+        $document = new DOMDocument("1.0", "UTF-8");
+        $document->loadHTML(Helper::HTML_SELECTORS);
+        $xpath = new DOMXPath($document);
+
+        $classIdTranslator = new Translator(".content#content-element");
+        $classAttr2Translator = new Translator(".content[data-attr='2']");
+
+        $titleEl = $xpath->query($classIdTranslator)->item(0);
+        self::assertEquals("Content with ID", $titleEl->nodeValue);
+
+        $attr2El = $xpath->query($classAttr2Translator)->item(0);
+        self::assertEquals("Content with attribute 2", $attr2El->nodeValue);
+    }
+
+    public function testChildWithAttribute() {
+        $document = new DOMDocument("1.0", "UTF-8");
+        $document->loadHTML(Helper::HTML_CHECKBOX);
+        $xpath = new DOMXPath($document);
+        $choiceTranslator = new Translator("form [name]");
+        $choiceInputs = $xpath->query($choiceTranslator);
+        self::assertEquals(3, $choiceInputs->length);
+    }
 }


### PR DESCRIPTION
This fixes #63, but also incorrect queries from selectors that combined multiple things, e.g. id and class, or class and attribute.