### PR TITLE
Make tag names case-insensitive in HTML mode

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -67,7 +67,11 @@ class Translator {
 			switch ($currentThreadItem["type"]) {
 			case "star":
 			case "element":
-				$xpath []= $currentThreadItem['content'];
+				if($this->htmlMode) {
+					$xpath []= strtolower($currentThreadItem['content']);
+				} else {
+					$xpath []= $currentThreadItem['content'];
+				}
 				$hasElement = true;
 				break;
 

--- a/test/phpunit/TranslatorTest.php
+++ b/test/phpunit/TranslatorTest.php
@@ -211,6 +211,14 @@ class TranslatorTest extends TestCase {
 			0,
 			$xpath->query($attributeValueCaseSensitive)->length
 		);
+		
+		$tagNameCaseInsensitive = new Translator(
+			"dIv"
+		);
+		self::assertEquals(
+			1,
+			$xpath->query($tagNameCaseInsensitive)->length
+		);
 
 	}
 


### PR DESCRIPTION
Given that [HTML tag names are case insensitive ](https://www.w3.org/TR/2010/WD-html-markup-20101019/documents.html#case-insensitivity), a query for 'DIV', 'div' or 'DiV' should all match an element written any of these ways.

In my [PR adding code to support case-insensitive matching on attribute names](https://github.com/PhpGt/CssXPath/pull/219), I neglected to copy the code from my experimental branch to extend this to tag names. 

This PR fixes that. 