### PR TITLE
Fix for PHP 8.4

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -279,7 +279,7 @@ class Translator {
 	protected function preg_match_collated(
 		string $regex,
 		string $string,
-		callable $transform = null
+		?callable $transform = null
 	):array {
 		preg_match_all(
 			$regex,


### PR DESCRIPTION
> Deprecated: Gt\CssXPath\Translator::preg_match_collated(): Implicitly marking parameter $transform as nullable is deprecated, the explicit nullable type must be used instead in ./phpgt/cssxpath/src/Translator.php on line 279

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types