### PR TITLE
Add JetBrains sponsorship to README with H1 heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,9 @@ It's perhaps worth noting that for XML-style matching to work, you must load the
 
 [qsa]: https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll
 [gt-dom]: https://www.php.gt/dom
+
+# Proudly sponsored by
+
+[JetBrains Open Source sponsorship program](https://www.jetbrains.com/community/opensource/)
+
+[![JetBrains logo.](https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.svg)](https://www.jetbrains.com/community/opensource/)


### PR DESCRIPTION
This PR adds JetBrains sponsorship information to the README.md file with an H1 heading.